### PR TITLE
Adapt standard mcp config for Windows usage

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,6 +121,7 @@ Open config file
 ```
 
 **Windows**:
+This file does not exist by default. You can create it by going in Claude Desktop to Settings > Developer > Edit config. Or just create the file yourself.
 ```
 %APPDATA%\Claude\claude_desktop_config.json
 ```
@@ -156,6 +157,7 @@ echo "Python Path: $(which python3)"
         "CHECKMK_USERNAME": "vibemk",
         "CHECKMK_PASSWORD": "Your_real_API_key_here",
         "CHECKMK_VERIFY_SSL": "true",
+        "PYTHONIOENCODING": "utf-8"
       }
     }
   }
@@ -176,7 +178,8 @@ echo "Python Path: $(which python3)"
         "CHECKMK_PASSWORD": "cmk_api_key_here",
         "CHECKMK_VERIFY_SSL": "true",
         "CHECKMK_TIMEOUT": "30",
-        "CHECKMK_MAX_RETRIES": "3"
+        "CHECKMK_MAX_RETRIES": "3",
+        "PYTHONIOENCODING": "utf-8"
       }
     }
   }


### PR DESCRIPTION
# Pull Request

## Description
I encountered the error: UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f50d'
This is caused by Python trying to print Unicode (emoji) characters to a Windows console that uses the default cp1252 encoding, which can't handle many Unicode symbols (like emojis).
The error happens when the server tries to print the JSON response for the tools list, which contains emoji in tool descriptions.

## Type of Change
- [x] Documentation update

## Testing
- [x] I have tested this change locally

## CheckMK Integration
- [x] This change works with CheckMK version: any
- [x] I have tested the MCP protocol integration
- [x] No sensitive information (API keys, passwords) is exposed in logs or commits

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated the USER_GUIDE.md if needed
- [x] I have updated the INSTALLATION.md if needed

## Security
- [x] This change does not expose sensitive information
- [x] API authentication mechanisms work as expected
- [x] SSL/TLS configuration is maintained

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published